### PR TITLE
Enable inference func to bert(finetune_classifier)

### DIFF
--- a/scripts/bert/finetune_classifier.py
+++ b/scripts/bert/finetune_classifier.py
@@ -211,7 +211,7 @@ def preprocess_data(tokenizer, task, batch_size, dev_batch_size, max_len):
         tokenizer,
         max_len,
         labels=task.get_labels(),
-        pad=False,
+        pad=True,
         pair=task.is_pair,
         label_dtype='float32' if not task.get_labels() else 'int32')
 

--- a/scripts/bert/finetune_classifier.py
+++ b/scripts/bert/finetune_classifier.py
@@ -418,8 +418,8 @@ def inference(metric):
 
         mx.nd.waitall()
 
-    toc = time.time()
-    logging.info('Time cost={:.1f}s'.format(toc - tic))
+        toc = time.time()
+        logging.info('Time cost={:.1f}s'.format(toc - tic))
 
 
 if __name__ == '__main__':

--- a/scripts/bert/finetune_classifier.py
+++ b/scripts/bert/finetune_classifier.py
@@ -370,13 +370,14 @@ def train(metric):
         toc = time.time()
         logging.info('Time cost={:.1f}s'.format(toc - tic))
 
-        # Save parameters
-        validation_acc = metric.get()[1][0]
-        if validation_acc > best_acc:
-            save_path = os.path.join(args.save_dir, 'valid_best.params')
-            model.save_parameters(save_path)
-            best_acc = validation_acc
-            logging.info('the best acc is updata, and valid_best params saved as:{}'.format(save_path))
+        # Save parameters for MRPC task
+        if task_name in ['MRPC']:
+            validation_acc = metric.get()[1][0]
+            if validation_acc > best_acc:
+                save_path = os.path.join(args.save_dir, 'MRPC_valid_best.params')
+                model.save_parameters(save_path)
+                best_acc = validation_acc
+                logging.info('the best acc is updata, and valid_best params saved as:{}'.format(save_path))
 
 
 def inference(metric):
@@ -385,7 +386,7 @@ def inference(metric):
     logging.info('|----- Now we are doing BERT inference at {} !'.format(ctx))
     model = BERTClassifier(
         bert, dropout=0.1, num_classes=len(task.get_labels()))
-    para_name = 'valid_best.params'
+    para_name = 'MRPC_valid_best.params'
     model.load_parameters(os.path.join(args.save_dir, para_name), ctx=ctx)
 
     for epoch_id in range(1):

--- a/scripts/bert/index.rst
+++ b/scripts/bert/index.rst
@@ -34,7 +34,7 @@ Use the following command to fine-tune the BERT model for classification on the 
 
 .. code-block:: console
 
-   $ MXNET_GPU_MEM_POOL_TYPE=Round GLUE_DIR=glue_data finetune_classifier.py --task_name MRPC --batch_size 32 --optimizer bertadam --epochs 3 --gpu --lr 2e-5
+   $ MXNET_GPU_MEM_POOL_TYPE=Round GLUE_DIR=glue_data python3 finetune_classifier.py --task_name MRPC --batch_size 32 --optimizer bertadam --epochs 3 --gpu --lr 2e-5
 
 It gets validation accuracy of `88.7% <https://raw.githubusercontent.com/dmlc/web-data/master/gluonnlp/logs/bert/finetuned_mrpc.log>`_, whereas the the original Tensorflow implementation give evaluation results between 84% and 88%.
 
@@ -44,5 +44,13 @@ It gets validation accuracy of `88.7% <https://raw.githubusercontent.com/dmlc/we
 
 It gets RTE validation accuracy of `70.8% <https://raw.githubusercontent.com/dmlc/web-data/master/gluonnlp/logs/bert/finetuned_rte.log>`_
 , whereas the the original Tensorflow implementation give evaluation results 66.4%.
+
+Use the following command to make inference of fine-tuned BERT model for classification on the GLUE(MRPC) dataset.
+
+.. code-block:: console
+
+   $ MXNET_GPU_MEM_POOL_TYPE=Round GLUE_DIR=glue_data python3 finetune_classifier.py --task_name MRPC --batch_size 32 --run_type inference
+
+before doing inference, please first doing training at least once time to save fine-tuned parameters.
 
 Some other tasks can be modeled with `--task_name` parameter.

--- a/scripts/bert/index.rst
+++ b/scripts/bert/index.rst
@@ -45,7 +45,7 @@ It gets validation accuracy of `88.7% <https://raw.githubusercontent.com/dmlc/we
 It gets RTE validation accuracy of `70.8% <https://raw.githubusercontent.com/dmlc/web-data/master/gluonnlp/logs/bert/finetuned_rte.log>`_
 , whereas the the original Tensorflow implementation give evaluation results 66.4%.
 
-Use the following command to make inference of fine-tuned BERT model for classification on the GLUE(MRPC) dataset.
+Use the following command to make inference of fine-tuned BERT model for classification on the MRPC dataset.
 
 .. code-block:: console
 

--- a/scripts/bert/index.rst
+++ b/scripts/bert/index.rst
@@ -49,7 +49,7 @@ Use the following command to make inference of fine-tuned BERT model for classif
 
 .. code-block:: console
 
-   $ MXNET_GPU_MEM_POOL_TYPE=Round GLUE_DIR=glue_data python3 finetune_classifier.py --task_name MRPC --batch_size 32 --run_type inference
+   $ GLUE_DIR=glue_data python3 finetune_classifier.py --task_name MRPC --batch_size 32 --run_type inference
 
 before doing inference, please first doing training at least once time to save fine-tuned parameters.
 


### PR DESCRIPTION
## Description ##
Enable inference for finetune_classifier on the MRPC dataset. Add other module for inference:

- modle.save_parameters (save training parameters for inference)
- mx.profiler (do profiler for inference)

add two argument:

- save_dir (directory path to save the final model.)
- run_type (train or inference, default is train.)

before doing inference, please first doing training at least once to save parameters,and then use this code to run inference:
`MXNET_GPU_MEM_POOL_TYPE=Round GLUE_DIR=glue_data python finetune_classifier.py --task_name MRPC --batch_size 32 --gpu --run_type inference`

## Checklist ##
### Essentials ###
- [ ] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
